### PR TITLE
Revert "fix: jwt-go is deprecated, use golang-jwt as a drop-in"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.16
 require (
 	github.com/Masterminds/squirrel v1.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-redis/redis/v8 v8.10.0
-	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/jackc/pgproto3/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,6 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/http/api/v1/api.go
+++ b/pkg/http/api/v1/api.go
@@ -16,7 +16,7 @@ import (
 	// Until the echo middleware is updated, we have to use the
 	// old repo of the jwt module.
 	// "github.com/golang-jwt/jwt"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/rs/zerolog/log"

--- a/pkg/http/api/v1/api_test.go
+++ b/pkg/http/api/v1/api_test.go
@@ -11,7 +11,7 @@ import (
 	// Until the echo middleware is updated, we have to use the
 	// old repo of the jwt module.
 	// "github.com/golang-jwt/jwt"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/labstack/echo/v4"
 
 	"github.com/b3scale/b3scale/pkg/store"

--- a/pkg/http/api/v1/auth.go
+++ b/pkg/http/api/v1/auth.go
@@ -6,7 +6,7 @@ import (
 	// "github.com/golang-jwt/jwt"
 	"net/http"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 


### PR DESCRIPTION
Reverts b3scale/b3scale#7