### PR TITLE
fix: do not reset meeting info when calling create on existing meeting

### DIFF
--- a/pkg/cluster/backend.go
+++ b/pkg/cluster/backend.go
@@ -390,13 +390,6 @@ func (b *Backend) Create(
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		// Update state, associate with backend and frontend
-		meetingState.Meeting = createRes.Meeting
-		meetingState.SyncedAt = time.Now().UTC()
-		if err := meetingState.Save(ctx, tx); err != nil {
-			return nil, err
-		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {


### PR DESCRIPTION
When calling create on a meeting that already exists (which Greenlight does before every join) the meeting info/metrics in the database would be reset because the BBB does not return meeting info with the concurrent participantCount etc. if the meeting already exists.

From our understanding (reading BBB docs and scalelite source code) none of the attributes in the meeting info can be manipulated with a create request on an existing meeting, so setting the Meeting Info from the response of the create request should not be done for existing meetings.

fixes #19 