### PR TITLE
fix: Go wants an explicit cast of dbPoolSize to int32

### DIFF
--- a/cmd/b3scaled/main.go
+++ b/cmd/b3scaled/main.go
@@ -37,10 +37,11 @@ func main() {
 	revProxyEnabled := config.IsEnabled(config.EnvOpt(
 		config.EnvReverseProxy, config.EnvReverseProxyDefault))
 
-	dbPoolSize, err := strconv.ParseInt(dbPoolSizeStr, 10, 32)
+	dbPoolSize64, err := strconv.ParseInt(dbPoolSizeStr, 10, 32)
 	if err != nil {
 		log.Fatal().Err(err).Msg("database pool size")
 	}
+	dbPoolSize := int32(dbPoolSize64)
 
 	// Configure logging
 	if err := logging.Setup(&logging.Options{
@@ -68,7 +69,7 @@ func main() {
 	}
 
 	log.Info().
-		Int("maxConnections", dbPoolSize).
+		Int32("maxConnections", dbPoolSize).
 		Msg("database pool")
 
 	// Recordings are an optional feature, so we will treat errors


### PR DESCRIPTION
the compiler was fine with the previous state, but the linter was not.