### PR TITLE
fix: error when deleting recordings

### DIFF
--- a/pkg/middlewares/requests/recordings_request_handler.go
+++ b/pkg/middlewares/requests/recordings_request_handler.go
@@ -383,6 +383,9 @@ func (h *RecordingsHandler) DeleteRecordings(
 	}
 
 	res := &bbb.DeleteRecordingsResponse{
+		XMLResponse: &bbb.XMLResponse{
+			Returncode: bbb.RetSuccess,
+		},
 		Deleted: true,
 	}
 	res.SetStatus(http.StatusOK)


### PR DESCRIPTION
Deleting recordings would cause an error because the DeleteRecordingsResponse was not constructed correctly. This PR fixes this error.