### PR TITLE
feat: allow reading API from env

### DIFF
--- a/cmd/b3scalectl/cli.go
+++ b/cmd/b3scalectl/cli.go
@@ -36,6 +36,7 @@ func NewCli() *Cli {
 				Name:    "api",
 				Aliases: []string{"b"},
 				Value:   "http://" + config.EnvListenHTTPDefault,
+				EnvVars: []string{config.EnvAPIURL},
 			},
 		},
 		Action: c.showStatusHelp,


### PR DESCRIPTION
This allows users to specify the B3SCALE_API_URL environment variable as an alternative to using the --api cli flag to set the API endpoint to use with b3scalectl.