### PR TITLE
feat: rewrite provied analytics-callback-url callback as well

### DIFF
--- a/pkg/bbb/request.go
+++ b/pkg/bbb/request.go
@@ -29,6 +29,7 @@ const (
 	ParamDisabledFeatures = "disabledFeatures"
 	ParamMeetingEndedURL  = "meetingEndedURL"
 
+	MetaParamAnalyticsCallbackURL  = "meta_analytics-callback-url"
 	MetaParamMeetingEndCallbackURL = "meta_endCallbackUrl"
 	MetaParamRecordingReadyURL     = "meta_bbb-recording-ready-url"
 )

--- a/pkg/middlewares/requests/rewrite_meta_callback_urls.go
+++ b/pkg/middlewares/requests/rewrite_meta_callback_urls.go
@@ -31,6 +31,7 @@ func rewriteCallbacks(
 ) error {
 	callbacks := []string{
 		bbb.MetaParamRecordingReadyURL,
+		bbb.MetaParamAnalyticsCallbackURL,
 		bbb.MetaParamMeetingEndCallbackURL,
 		bbb.ParamMeetingEndedURL,
 	}

--- a/pkg/middlewares/requests/rewrite_meta_callback_urls_test.go
+++ b/pkg/middlewares/requests/rewrite_meta_callback_urls_test.go
@@ -24,9 +24,10 @@ func TestRewriteMetaCallbackURLs(t *testing.T) {
 	ctx := cluster.ContextWithFrontend(context.Background(), frontend)
 	req := &bbb.Request{
 		Params: bbb.Params{
-			bbb.MetaParamMeetingEndCallbackURL: "originalURL1",
-			bbb.MetaParamRecordingReadyURL:     "originalURL2",
-			bbb.ParamMeetingEndedURL:           "originalURL3",
+			bbb.MetaParamAnalyticsCallbackURL:  "originalURL1",
+			bbb.MetaParamMeetingEndCallbackURL: "originalURL2",
+			bbb.MetaParamRecordingReadyURL:     "originalURL3",
+			bbb.ParamMeetingEndedURL:           "originalURL4",
 		},
 	}
 
@@ -43,6 +44,14 @@ func TestRewriteMetaCallbackURLs(t *testing.T) {
 	}
 	t.Log(newURL)
 
+	if !strings.HasPrefix(
+		newURL,
+		"https://b3s.example.com/api/v1/callbacks/proxy/") {
+		t.Error("unexpected url:", newURL)
+	}
+	t.Log(newURL)
+
+	newURL = req.Params[bbb.MetaParamAnalyticsCallbackURL]
 	if !strings.HasPrefix(
 		newURL,
 		"https://b3s.example.com/api/v1/callbacks/proxy/") {


### PR DESCRIPTION
This provides access to the meeting's event.xml.