### PR TITLE
feat: better algorithm for calculating backend stress

### DIFF
--- a/pkg/cluster/backend.go
+++ b/pkg/cluster/backend.go
@@ -143,11 +143,14 @@ func GetBackend(
 func (b *Backend) Stress() float64 {
 	f := b.state.LoadFactor
 
-	// Assume a base load of n attendees. This should come from
-	// some a config or should be set per frontend.
+	// Assume a base load of n attendees per meeting. This should come from
+	// some a config or should be set per frontend or even be hinted from the create() call.
 	attendeeBaseLoad := 15.0
-	attendeeLoad := math.Max(attendeeBaseLoad, float64(b.state.AttendeesCount))
-	return f * (float64(b.state.MeetingsCount) + attendeeLoad)
+
+	// Assume that every Meeting will eventually have attendeeBaseLoad attendees on average,
+	// but use AttendeesCount if bigger. A rough estimate, but cheap to calculate.
+	minAssumedAttendees := math.Max(float64(b.state.MeetingsCount)*attendeeBaseLoad, float64(b.state.AttendeesCount))
+	return f * minAssumedAttendees
 }
 
 // refreshNodeState will fetch all meetings from the backend.

--- a/pkg/cluster/backend_test.go
+++ b/pkg/cluster/backend_test.go
@@ -13,11 +13,16 @@ func TestBackendStress(t *testing.T) {
 		LoadFactor:     1,
 		AttendeesCount: 12,
 	}}
-	if b.Stress() != 25 {
+	if b.Stress() != 150 {
 		t.Error("unexpected result for stress function:", b.Stress())
 	}
 	b.state.LoadFactor = 1.25
-	if b.Stress() != 31.25 {
+	if b.Stress() != 187.5 {
+		t.Error("unexpected result for stress function:", b.Stress())
+	}
+	b.state.LoadFactor = 1.0
+	b.state.AttendeesCount = 600
+	if b.Stress() != 600 {
 		t.Error("unexpected result for stress function:", b.Stress())
 	}
 }


### PR DESCRIPTION
So far, creating a new room increased stress just as much as adding a new attendee. Now, we assume that every meeting as an avg of 15 attendees, but if the backend hosts more attendees than calculated through above algorithm, use the total backend attendee count instead.