### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@
 #
 
 name: Test
+permissions:
+  contents: read
 
 on: [ push, workflow_dispatch ]
 


### PR DESCRIPTION
Potential fix for [https://github.com/b3scale/b3scale/security/code-scanning/6](https://github.com/b3scale/b3scale/security/code-scanning/6)

The best way to fix this issue is to explicitly declare a `permissions` block for the workflow (at the top level, just after the `name` and before `on:`) or specifically for jobs as appropriate. Since this workflow's steps only check out code, set up Go, format/lint code, and run tests (all local actions), it only needs `contents: read`. Adding the line `permissions: { contents: read }` directly below the workflow `name:` is most straightforward, as it applies least-privilege permissions to all jobs unless overridden elsewhere. No additional code, imports, or methods are needed—just this one YAML line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
